### PR TITLE
35-logObsAndProps

### DIFF
--- a/JSWC/Init.aplf
+++ b/JSWC/Init.aplf
@@ -6,7 +6,7 @@
  :Case 1 ⋄ mode←⊃args ⋄ CODELOCATION←⊃⎕RSI
  :Case 2 ⋄ (mode CODELOCATION)←args
  :Else
-     'Right agument: mode [codelocation]'⎕SIGNAL 5
+     'Right argument: mode [codelocation]'⎕SIGNAL 5
  :EndSelect
 
  :If 0=⎕NC'prefix'
@@ -49,7 +49,9 @@
      MAXLOG←2000
  :EndIf
  :If 0=⎕NC'LOGMODES'
-     LOGMODES←⎕A ⍝ Log everything (see Log)
+     :If 0=≢LOGMODES←1⊃160⌶'EWC_LOGMODES'   ⍝ do we have a default in the environment?
+         LOGMODES←⎕A ⍝ Log everything (see Log)
+     :EndIf
  :EndIf
  :If 0=⎕NC'RESOURCES'
      RESOURCES←1 2⍴⊂''
@@ -79,7 +81,7 @@
      make_JSWC CODELOCATION ⍝ So create the timer here
  :EndIf
 
- :If 9=⎕NC 'WSS'
+ :If 9=⎕NC'WSS'
      ⎕←'Closing existing Web Socket Server...'
      WSS.Stop
      ⎕DL 5
@@ -121,7 +123,7 @@
      (⍕z)⎕SIGNAL 11
  :EndIf
 
- :If 4≥⍴devCaps←'.' ⎕WG 'DevCaps'
+ :If 4≥⍴devCaps←'.'⎕WG'DevCaps'
      DPR←100÷⍨4⊃devCaps
  :Else
      DPR←1

--- a/JSWC/Log.aplf
+++ b/JSWC/Log.aplf
@@ -1,4 +1,4 @@
-mode Log msg
+ mode Log msg;json
 ⍝ Log modes: Controlled by JSWC.LOGMODES
 ⍝ D: Debug
 ⍝ E: Error
@@ -8,6 +8,18 @@ mode Log msg
 ⍝ R: Receive on WebSocket
 ⍝ C: Connect or Disconnect
 ⍝ U: Unsupported feature
+⍝ w: log eW* object/property access (for testing)
 
-→(mode∊LOGMODES)↓0
-⎕←((,'ZI2,<:>,ZI2,<.>,ZI3' ⎕FMT 1 3⍴¯3↑⎕TS),' ',mode,':') msg
+ →(mode∊LOGMODES)↓0
+ ⎕←((,'ZI2,<:>,ZI2,<.>,ZI3'⎕FMT 1 3⍴¯3↑⎕TS),' ',mode,':')msg
+ :If mode≡'w'
+    ⍝ primitive: we collect json objects in that file - it's not "json" though...(needs to be enclosed in [])
+    ⍝ also we do not care about max file size, we just keep appending
+    ⍝ do it's the responsibility of the user to clean up the file.
+    ⍝ That's why mode='w' is useful - it's not part of the default (⎕A)
+    ⍝ and needs to be set explicitely!
+    ⍝ (see eWC Tests for example usage that deletes the file before running tests
+    ⍝  and also adds the "[]" )
+     msg←('(:.*,)(.*)$'⎕R('\1 TS: [',(∊(⍕¨¯4↑⎕TS),¨','),'],\2')⍠'Greedy' 0)msg
+     (⊂msg)⎕NPUT(JSWCFolder,'objectlog.json5')2
+ :EndIf

--- a/JSWC/dWC.aplf
+++ b/JSWC/dWC.aplf
@@ -117,6 +117,7 @@
  :EndIf
 
  'D' Log '*** CREATE ',WC.WC.Properties.Type,' ',WC.WC.ID,' at ',⍕3↑showCallStack
+ 'w' Log '{Caller: "',(2⊃⎕si),'", Action:"WC", ID:"',WC.WC.ID,'", Type:"',WC.WC.Properties.Type,'", Properties:[',(¯1↓∊{'"',⍵,'",'}¨propnames),']},'
  fixSendEvents WC.WC.(ID Properties)
  sendObject WC WC.WC.ID
 

--- a/JSWC/dWG.aplf
+++ b/JSWC/dWG.aplf
@@ -92,3 +92,5 @@
  :If 1=≡Props
      R←⊃R
  :EndIf
+
+ 'w' Log '{Caller: "',(2⊃⎕si),'", Action:"WG", ID:"', Name,'",Properties:[',(¯1↓∊{'"',⍵,'",'}¨p),']},'

--- a/JSWC/dWS.aplf
+++ b/JSWC/dWS.aplf
@@ -89,3 +89,5 @@
  :If ~0=⍴WS.WS.Properties.⎕NL-2
      sendObject WS WS.WS.ID
  :EndIf
+
+ 'w' Log '{Caller: "',(2⊃⎕si),'", Action:"WS", ID:"',WS.WS.ID,'", Properties:[',(¯1↓∊{'"',⍵,'",'}¨names),']},'

--- a/Tests/eWC_createBrowser.aplf
+++ b/Tests/eWC_createBrowser.aplf
@@ -1,6 +1,6 @@
  {larg}eWC_createBrowser rarg;cmd
 ⍝ ⍵ corresponds to Run's ⍵
 
- cmd←'LOAD=',EWC_HOME,' LX="demo.Run ',(⍕rarg),'" EWC_PORT=22344'
+ cmd←'LOAD=',EWC_HOME,' LX="demo.Run ',(⍕rarg),'" EWC_PORT=22344 EWC_LOGMODES=w',(1=0 _Env'TRACE_DEMOS')/' EWC_TRACEDEMOS=1'
  p←⎕NEW #.APLProcess(''cmd 0 '' ''EWC_HOME)     ⍝ do not localise this!
  #.S.InitBrowser larg

--- a/Tests/eWC_defaults.json5
+++ b/Tests/eWC_defaults.json5
@@ -2,4 +2,6 @@
     SCREENSHOT: 2,        // 0: never, 1: on error, 2: always
     RANDOMORDER: 1,       // execute tests in random order?
     PROGRESSINDICATOR: 1, // no info, 1: show name of next test, 2: and wait for keypress
+    TRACE_DEMOS: 0,      // trace into the demos?
+    TRACE_TESTS: 1,      // trace into the tests?
 }

--- a/demo/Run.aplf
+++ b/demo/Run.aplf
@@ -22,6 +22,10 @@
  :EndTrap
 
  JSWC.NOIDQ←0 ⍝ Allow interactive DQ
+ ⍝ trace into demo functions?
+ :If 1≡⊃2⊃⎕VFI 2 ⎕NQ'.' 'GetEnvironment' 'EWC_TRACEDEMOS'
+     #.demo.({'Demo'≡4↑⍵:1 ⎕STOP ⍵}¨(⎕NL-3)~'DemoMenu' 'DemoDefault')
+ :EndIf
 
  :Select JSWC.MODE
  :Case 0 ⍝ Desktop


### PR DESCRIPTION
This addresses issue #35: the logmode "w" (intentionally using lowercase to avoid excessive file-activity when using default modes ⎕A)  gathers information about ∆W* activity in a file. Path and filename are hardcodes to keep things easy (at least in this initial phase).
LOGMODES can now be set with a env/cfg variable named "EWC_LOGMODES" - so that any tests that want to use this info can control the setting as needed. Note that any calling program which activated that setting has to take care of removing the logfile itself.
Also: this log is not directly readable with ⎕JSON because it contains a list of records. The calling program needs to initialise this file with "[" and finally append a "]".  (see Test/eWC_test.aplf for an actual use case).