### PR TITLE
Cookies setting and getting & demo

### DIFF
--- a/EWC/supportedMethods.apla
+++ b/EWC/supportedMethods.apla
@@ -3,4 +3,6 @@
  'GetFocus'
  'SetCookie'
  'GetCookie'
+ 'SetTitle'
+ 'GetTitle'
 )

--- a/EWC/supportedMethods.apla
+++ b/EWC/supportedMethods.apla
@@ -1,4 +1,6 @@
 (
  'GetTextSize'
  'GetFocus'
+ 'SetCookie'
+ 'GetCookie'
 )

--- a/demo/CBClearCookie.aplf
+++ b/demo/CBClearCookie.aplf
@@ -1,0 +1,11 @@
+ CBClearCookie args;e;cookietoset
+
+ Event←⎕NS''
+ e←Event.Event←⎕NS''
+ e.(ID EventName Info)←(2↑args),⊂2↓args
+
+ cookietoset←'','F1.COOKIETOSET'eWG'Text'
+
+⍝ Clearing is just setting with a time in the past
+ 2 eNQ 'F1' 'SetCookie' ('democookie=;max-age=-1')
+ 'F1.G.COOKIES'eWS'Text' ('Cookie: CLEARED')

--- a/demo/CBRefreshCookie.aplf
+++ b/demo/CBRefreshCookie.aplf
@@ -1,0 +1,11 @@
+ CBRefreshCookie args;e;cookie
+
+ Event←⎕NS''
+ e←Event.Event←⎕NS''
+ e.(ID EventName Info)←(2↑args),⊂2↓args
+
+ cookie←2 eNQ 'F1' 'GetCookie' 'democookie'
+ :If 0≠≢cookie
+     cookie←2⊃⊃cookie
+ :EndIf
+ 'F1.G.COOKIES'eWS'Text' ('Cookie: ',cookie)

--- a/demo/CBSetCookie.aplf
+++ b/demo/CBSetCookie.aplf
@@ -1,0 +1,10 @@
+ CBSetCookie args;e;cookietoset
+
+ Event←⎕NS''
+ e←Event.Event←⎕NS''
+ e.(ID EventName Info)←(2↑args),⊂2↓args
+
+ cookietoset←'','F1.COOKIETOSET'eWG'Text'
+
+ 2 eNQ 'F1' 'SetCookie' ('democookie=',cookietoset)
+ 'F1.G.COOKIES'eWS'Text' ('Cookie: ',cookietoset)

--- a/demo/CBSetTitle.aplf
+++ b/demo/CBSetTitle.aplf
@@ -1,0 +1,9 @@
+ CBSetTitle args;e;titletoset
+
+ Event←⎕NS''
+ e←Event.Event←⎕NS''
+ e.(ID EventName Info)←(2↑args),⊂2↓args
+
+ titletoset←'','F1.TITLETOSET'eWG'Text'
+
+ 2 eNQ 'F1' 'SetTitle' titletoset

--- a/demo/DemoCookies.aplf
+++ b/demo/DemoCookies.aplf
@@ -1,0 +1,19 @@
+ DemoCookies connected;cookie;resp
+ EWC.CONNECTED←connected
+ ⎕PW←1000
+
+ 'F1'eWC'Form' 'Cookies'(50 50)(170 200)('Coord' 'Pixel')
+
+ 'F1.COOKIETOSET'eWC'Edit'('Posn' 50 10)('Size'(20 150))
+ 'F1.SETCOOKIE'eWC'Button' 'Set Cookie'('Posn' 75 10)('Size'(20 150))('Event' 'Select' 'CBSetCookie')
+ 'F1.REFRESHCOOKIE'eWC'Button' 'Refresh Cookie'('Posn' 100 10)('Size'(20 150))('Event' 'Select' 'CBRefreshCookie')
+ 'F1.CLEARCOOKIE'eWC'Button' 'Clear Cookie'('Posn' 125 10)('Size'(20 150))('Event' 'Select' 'CBClearCookie')
+
+ resp←2 eNQ 'F1' 'GetCookie' 'democookie'
+ cookie←2 eNQ 'F1' 'GetCookie' 'democookie'
+ :If 0≠≢cookie
+     cookie←2⊃⊃cookie
+ :EndIf
+
+ 'F1.G'eWC'Group'('Posn'(150 0))('Size'(20 200))
+ 'F1.G.COOKIES'eWC'Text' ('Cookie: ',cookie)(0 10)(20 400)

--- a/demo/DemoCookies.aplf
+++ b/demo/DemoCookies.aplf
@@ -1,4 +1,4 @@
- DemoCookies connected;cookie;resp
+ DemoCookies connected;cookie
  EWC.CONNECTED←connected
  ⎕PW←1000
 
@@ -9,7 +9,6 @@
  'F1.REFRESHCOOKIE'eWC'Button' 'Refresh Cookie'('Posn' 100 10)('Size'(20 150))('Event' 'Select' 'CBRefreshCookie')
  'F1.CLEARCOOKIE'eWC'Button' 'Clear Cookie'('Posn' 125 10)('Size'(20 150))('Event' 'Select' 'CBClearCookie')
 
- resp←2 eNQ 'F1' 'GetCookie' 'democookie'
  cookie←2 eNQ 'F1' 'GetCookie' 'democookie'
  :If 0≠≢cookie
      cookie←2⊃⊃cookie

--- a/demo/DemoTitle.aplf
+++ b/demo/DemoTitle.aplf
@@ -1,0 +1,12 @@
+ DemoTitle connected;title
+ EWC.CONNECTED←connected
+ ⎕PW←1000
+
+ 'F1'eWC'Form' 'Title'(50 50)(170 400)('Coord' 'Pixel')
+
+ 'F1.TITLETOSET'eWC'Edit'('Posn' 50 10)('Size'(20 150))
+ 'F1.SETTITLE'eWC'Button' 'Set Title'('Posn' 75 10)('Size'(20 150))('Event' 'Select' 'CBSetTitle')
+
+ title←2 eNQ 'F1' 'GetTitle'
+ 'F1.G'eWC'Group'('Posn'(100 0))('Size'(20 400))
+ 'F1.G.COOKIES'eWC'Text' ('Original title on demo load: ',title)(0 10)(20 400)


### PR DESCRIPTION
The only real change in EWC is to add SetCookie and GetCookie.

The demo shows setting, refreshing (in case cookies have been changed in the dev console, and clearing a cookie. Best way to test is to set a cookie and close things down and then come back again and see that the demo remembers.