### PR TITLE
Allow evaluation of JS pushed from the APL side.

### DIFF
--- a/EWC/supportedMethods.apla
+++ b/EWC/supportedMethods.apla
@@ -5,4 +5,5 @@
  'GetCookie'
  'SetTitle'
  'GetTitle'
+ 'EvalJS'
 )


### PR DESCRIPTION
Example call of two expressions:

⎕←2 eNQ'F1' 'EvalJS' '123 + 456' 'nonExistentFunc()'

This returns something like the below, where 0 is success and -1 if error thrown:

{"WX":{"Info":[[0,579],[-1,"ReferenceError: nonExistentFunc is not defined"]],"WGID":"515"}}

Copied commit message from the JS side:

This _feels_ dangerous, but isn't so bad. A user can already eval arbitrary code in any browser session. It opens no security issue for the APL server.

This is currently expected to be used to build some tooling to look around. Any modification of the DOM, etc, is likely to break React code very very quickly.

Experts/tool builders only though. Please.