### PR TITLE
Complete rewrite of normaliseEvents (with addition of Unit Tests)

### DIFF
--- a/EWC/EVENTS.apla
+++ b/EWC/EVENTS.apla
@@ -1,4 +1,5 @@
 [
+ 0   'All'
  1   'MouseDown'
  2   'MouseUp'
  3   'MouseMove'

--- a/EWC/NormaliseEvents.aplf
+++ b/EWC/NormaliseEvents.aplf
@@ -1,17 +1,12 @@
- r←normaliseEvents events;i;num;n
- :If events≡,⊂0 0 ⍝ Reset
-     →0 ⊣ r←events
+ r←normaliseEvents events;e;int;m
+ r←⊃,/normaliseEvent¨events
+
+ e←⌽⊃¨r ⍝ Extract individual events (in reverse order)
+ :If ∨/int←⍸(10|⎕DR¨e)∊1 3      ⍝ Numeric codes
+    m←int[⍸e[int]∊EVENTNUMS]    ⍝ Recognised numeric events
+    e[m]←eventNames[EVENTNUMS⍳e[m]]
  :EndIf
- :If 1=n←≢events
- :AndIf ∧/eventOK ⊃¨⊃events ⍝ Single element with multiple events
-     r←,/normaliseEvents¨⊃events
-  :ElseIf (4≥≢events)∧∧/eventOK 1⊃,⊆events ⍝ Multiple event names - but not one of the numeric event codes
-     r←↓(⍪⊆1⊃events),⊂1↓events
- :ElseIf ∧/eventOK ⊃¨events
-     r←⊃,/normaliseEvents¨events
-     r←((¯1+≢events)⍴⊂⍬),⊂r
- :Else
-     'U' Log 'Unsupported event setting at ',showCallStack
-     'U' Log '    'events
-     r←⍬
- :EndIf
+ e←⎕c (2×(2↑¨e)∊⊂'on')↓¨e ⍝ Drop leading 'on'
+ r←(⌽(⍳≢e)=e⍳e)/r         ⍝ Pick last
+
+ r←((¯1+≢events)⍴⊂⍬),⊂r   ⍝ Everything merged into last element (in case there were several Event property values)

--- a/EWC/normaliseEvent.aplf
+++ b/EWC/normaliseEvent.aplf
@@ -1,0 +1,8 @@
+r←normaliseEvent event;int;n;d;e
+
+int←(10|⎕DR¨event)∊1 3
+n←1⌈(¯1+≢int)⌊+/∧\int ⍝ Event is all leading numbers (but not the last element)
+e←n↑event ⋄ d←n↓event
+e←⊃⍣(3=≡e)⊢e          ⍝ Disclose vector of vectors or event names
+d←⊃⍣(1=≢d)⊢d          ⍝ Disclose when no left argument
+r←↓(⍪e),⊂d

--- a/EWC/processEvent.aplf
+++ b/EWC/processEvent.aplf
@@ -47,7 +47,7 @@
  :EndTrap
 
  (events fns)←↓⍉↑event
- :If ~∨/m←(t←'' 'on',¨⊂Event)∊events
+ :If ~∨/m←(t←(⊂Event),⊂'on',Event)∊events
      'E'Log'*** No callback defined for event ',Event,' on object ',ID
      →0
  :EndIf

--- a/EWC/processEvent.aplf
+++ b/EWC/processEvent.aplf
@@ -53,7 +53,7 @@
  :EndIf
 
  Event←⊃m/t ⍝ Event or onEvent
- fn←⊃info←(events⍳⊂Event)⊃fns
+ fn←⊃info←,⊆(events⍳⊂Event)⊃fns
  'P' Log 'Action = ',(⍕fn),' for ',(⎕JSON ns.Event),' at ',⎕SI,¨'[',¨(⍕¨⎕LC),¨']'
  →((fn≡¯1)∨end←fn≡1)⍴0
 

--- a/EWC/updateEvent.aplf
+++ b/EWC/updateEvent.aplf
@@ -1,3 +1,3 @@
 Event←updateEvent (old names values);m
 m←~(⊃¨old)∊names,2↓¨names
-Event←(m/old),↓names,⍪values
+Event←(m/old),↓names,⍪{⊃⍣(1=≢⍵)⊢⍵}¨values

--- a/demo/DemoEventTests.aplf
+++ b/demo/DemoEventTests.aplf
@@ -21,6 +21,6 @@
      'F1.NotePad'eWS'Event' 'MouseDown' 'CBMultiEdit'
  :EndIf
 
-:If F1.NotePad.Event ≢ ('MouseUp' (,⊂'CBMultiEdit'))(((2×~d)↓'onMouseDown') (,⊂'CBMultiEdit'))
+:If F1.NotePad.Event ≢ ('MouseUp' 'CBMultiEdit')(((2×~d)↓'onMouseDown') 'CBMultiEdit')
     ⎕←'Event does not have expected value' ⋄ ∘∘∘
 :EndIf

--- a/tests/assert.aplf
+++ b/tests/assert.aplf
@@ -1,5 +1,12 @@
 text assert (expect got)
 →(expect≡got)⍴0
-⎕←text
-⎕←'expected' 'got',⍪expect got
-'assertion failed' ⎕signal 11
+
+:If 0=⎕NC 'signal'
+:OrIf signal=1
+    ⎕←text
+    ⎕←'expected' 'got',⍪expect got
+    'assertion failed' ⎕signal 11
+:Else
+    ⎕←'failed: ',text
+    failed+←1
+:EndIf

--- a/tests/normaliseEventsTest.aplf
+++ b/tests/normaliseEventsTest.aplf
@@ -1,0 +1,3 @@
+ normaliseEventsTest(in out)
+
+ ('normaliseEvents: ',,⍕in)assert out(#.EWC.normaliseEvents in)

--- a/tests/proxySpaceTest.aplf
+++ b/tests/proxySpaceTest.aplf
@@ -1,11 +1,11 @@
- prefixes pSTest(expr syntax label);prefix;x;is;val
+ prefixes proxySpaceTest(expr syntax label);prefix;x;is;val
 
  :For prefix :In prefixes
      is←iSyntax ⎕←x←prefix,expr
      ('iSyntax: ',expr)assert syntax is
      val←iEvaluate(⊂x),is
-     :If 3=⎕NC 'val'
-         ('iEvaluate: ',expr)assert(⎕VR expr)(⎕VR 'val')
+     :If 3=⎕NC'val'
+         ('iEvaluate: ',expr)assert(⎕VR expr)(⎕VR'val')
      :Else
          ('iEvaluate: ',expr)assert(⍎expr)val
      :EndIf

--- a/tests/test_normaliseEvents.aplf
+++ b/tests/test_normaliseEvents.aplf
@@ -1,0 +1,26 @@
+r←test_normaliseEvents;t;e1;e2;e;in;out;signal;lm;i;failed
+
+e1←'MsgBtn1' 'MsgBtn2' 'MsgBtn3'
+e2←'CellChanged' 'CellDown' 'CellDblClick' 'CellMove' 'KeyPress'
+
+⍝ input event                                expected normalised output
+t←1 2⍴e                                      (e←(999 1)(1204  'cb1204')('Close' 1))
+t⍪←e                                         (e←('BadValue' ¯1)('KeyPress' '#.KeyPress'))
+t⍪←e                                         (e←,⊂'Select' 'CBRunDemo')
+t⍪←(,⊂e1 1)                                  (↓(⍪e1),1)
+t⍪←(,⊂e2 'EWCUpdate')                        (↓(⍪e2),⊂'EWCUpdate')
+t⍪←(,⊂'MouseDown' 'onMouseDown' 1)           (,⊂'MouseDown' ('onMouseDown' 1))
+t⍪←(,⊂'ContextMenu' 'doPopup' 'E')           (,⊂'ContextMenu' ('doPopup' 'E'))
+t⍪←(,⊂0 0)                                   (,⊂0 0)
+t⍪←(,⊂1 2 1000 0)                            ((1 0)(2 0)(1000 0))
+
+(failed signal)←0 0 ⍝ Do not crash
+lm←#.EWC.LOGMODES
+#.EWC.LOGMODES~←'U' ⍝ Do not log "unsupported" warnings
+:For i :In ⍳≢t
+    (in out)←t[i;]
+    normaliseEventsTest in (((¯1+≢in)⍴⊂⍬),⊂out)
+:EndFor
+#.EWC.LOGMODES←lm
+
+r←(⍕≢t),' tests run, ',(⍕failed),' failure(s)'

--- a/tests/test_proxySpace.aplf
+++ b/tests/test_proxySpace.aplf
@@ -6,13 +6,13 @@
  'A' 'A.B' ⎕NS¨⊂'Monadic' 'abc' 'def'
  spaces←'' 'A.' 'A.B.'
 
- spaces pSTest'abc'(2 0)'plain variable'
- spaces pSTest'(abc def)'(2 0)'multiple variables'
- spaces pSTest'Monadic'(3 52)'function'
- spaces pSTest'(Monadic abc)'(3 52)'monadic function call'
- spaces pSTest'(abc×2)'(3 32)'expression'
+ spaces proxySpaceTest 'abc'(2 0)'plain variable'
+ spaces proxySpaceTest '(abc def)'(2 0)'multiple variables'
+ spaces proxySpaceTest 'Monadic'(3 52)'function'
+ spaces proxySpaceTest '(Monadic abc)'(3 52)'monadic function call'
+ spaces proxySpaceTest '(abc×2)'(3 32)'expression'
 
- ⍝ Check for changes during testing :P
+ ⍝ Check for code changes during testing :P
  :For f :In 'iSyntax' 'iEvaluate'
      :If (⎕NR f)≢##.EWC.proxySpace.⎕NR f
          z←##.EWC.proxySpace.⎕FX ⎕NR f


### PR DESCRIPTION
The addition of direct access to properties broke the existing implementation of normaliseEvents, which was much to complicated to understand and refactor.