### PR TITLE
Ping

### DIFF
--- a/EWC/Handler.aplf
+++ b/EWC/Handler.aplf
@@ -1,6 +1,10 @@
  r←con Handler payload;ns;Event;ID;Info;events;fns;fn;event;reqfn;info;sns;i;code;conn;coni;sock;z;m;msg;sessionspace;form;hr;CALLER;app;new;old;token;TID;URL
  ⎕TRAP←0 'S'
- 'R'Log'#',(⍕con),': ',payload
+ :If payload≡'{"Event":{"EventName":"Ping","ID":""}}'
+     'K'Log payload
+ :Else
+     'R'Log'#',(⍕con),': ',payload
+ :EndIf
  i←(2⊃SESSIONS)⍳con
  :If i>≢1⊃SESSIONS
      'W'Log'Message received from closed session #',⍕con

--- a/EWC/Log.aplf
+++ b/EWC/Log.aplf
@@ -11,6 +11,7 @@ mode Log msg
 ⍝ N: Explicit NQ
 ⍝ P: ProcessEvent
 ⍝ G: WG
+⍝ K: Keep-Alive
 
 →(mode∊LOGMODES)↓0
 ⎕←((,'ZI2,<:>,ZI2,<.>,ZI3' ⎕FMT 1 3⍴¯3↑⎕TS),' ',mode,':') msg

--- a/EWC/processEvent.aplf
+++ b/EWC/processEvent.aplf
@@ -27,7 +27,6 @@
 ⍝ Ping exists purely as a mechanism to keep a connection alive. We simply drop
 ⍝ the event.
  :If Event≡'Ping'
-    ⍝  'E' Log 'Ping'
      →0
  :EndIf
 

--- a/EWC/processEvent.aplf
+++ b/EWC/processEvent.aplf
@@ -24,6 +24,13 @@
      →0
  :EndIf
 
+⍝ Ping exists purely as a mechanism to keep a connection alive. We simply drop
+⍝ the event.
+ :If Event≡'Ping'
+    ⍝  'E' Log 'Ping'
+     →0
+ :EndIf
+
  :If Event≡'KeyPress'
  :AndIf (≢JSKeys)≥z←JSKeys⍳Info[1]
      shift←4⊃Info


### PR DESCRIPTION
Ping events exist only as a mechanism to prevent over-zealous proxies or gateways disconnecting our websocket.

We simply drop them. See https://github.com/Dyalog/ewc-client/issues/313