### PR TITLE
ci: add release workflows

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,131 @@
+name: Prepare Release
+
+on:
+  push:
+    branches: [main]
+    paths: ['RELEASES.md']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout EWC
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Parse top release section
+        id: parse
+        run: |
+          set -euo pipefail
+          version=$(awk '/^## \[v[0-9]+\.[0-9]+\.[0-9]+\]/ {
+            match($0, /v[0-9]+\.[0-9]+\.[0-9]+/)
+            print substr($0, RSTART, RLENGTH)
+            exit
+          }' RELEASES.md)
+
+          if [ -z "$version" ]; then
+            echo "::notice::No versioned section in RELEASES.md (only Unreleased?). Nothing to do."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" { found = 1; next }
+            /^## / && found { exit }
+            found { print }
+          ' RELEASES.md > /tmp/notes.md
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag already exists
+        if: steps.parse.outputs.skip != 'true'
+        id: tag_check
+        run: |
+          if git rev-parse "refs/tags/${{ steps.parse.outputs.version }}" >/dev/null 2>&1; then
+            echo "::notice::Tag ${{ steps.parse.outputs.version }} already exists; nothing to do."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Clone ewc-client
+        if: steps.parse.outputs.skip != 'true' && steps.tag_check.outputs.exists != 'true'
+        run: |
+          git clone --depth=1 https://github.com/dyalog/ewc-client.git /tmp/ewc-client
+          echo "EWC_CLIENT_SHA=$(git -C /tmp/ewc-client rev-parse --short HEAD)" >> "$GITHUB_ENV"
+
+      - name: Refresh client/dist from ewc-client
+        if: steps.parse.outputs.skip != 'true' && steps.tag_check.outputs.exists != 'true'
+        id: refresh
+        run: |
+          rm -rf client/dist
+          mkdir -p client
+          cp -R /tmp/ewc-client/dist client/dist
+
+          if git diff --quiet -- client/dist; then
+            echo "client/dist unchanged"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "client/dist updated"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open release PR (dist changed)
+        if: |
+          steps.parse.outputs.skip != 'true' &&
+          steps.tag_check.outputs.exists != 'true' &&
+          steps.refresh.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.parse.outputs.version }}"
+          branch="release/$version"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add client/dist
+          git commit -m "chore(release): $version - refresh client/dist from ewc-client@${EWC_CLIENT_SHA}"
+          git push -f origin "$branch"
+
+          gh label create release --color 0e8a16 --description "Release PRs" 2>/dev/null || true
+
+          pr=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')
+          if [ -z "$pr" ]; then
+            gh pr create --base main --head "$branch" \
+              --title "Release $version" \
+              --body-file /tmp/notes.md \
+              --label release
+          else
+            gh pr edit "$pr" --body-file /tmp/notes.md
+          fi
+
+      - name: Tag and release directly (no dist change)
+        if: |
+          steps.parse.outputs.skip != 'true' &&
+          steps.tag_check.outputs.exists != 'true' &&
+          steps.refresh.outputs.changed != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.parse.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$version" -m "Release $version"
+          git push origin "$version"
+
+          (cd client && zip -r /tmp/client-dist.zip dist)
+
+          gh release create "$version" \
+            --title "$version" \
+            --notes-file /tmp/notes.md \
+            /tmp/client-dist.zip

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,74 @@
+name: Publish Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main (post-merge)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Parse top release section
+        id: parse
+        run: |
+          set -euo pipefail
+          version=$(awk '/^## \[v[0-9]+\.[0-9]+\.[0-9]+\]/ {
+            match($0, /v[0-9]+\.[0-9]+\.[0-9]+/)
+            print substr($0, RSTART, RLENGTH)
+            exit
+          }' RELEASES.md)
+
+          if [ -z "$version" ]; then
+            echo "::error::No versioned section found in RELEASES.md"
+            exit 1
+          fi
+
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" { found = 1; next }
+            /^## / && found { exit }
+            found { print }
+          ' RELEASES.md > /tmp/notes.md
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if tag already exists
+        id: tag_check
+        run: |
+          if git rev-parse "refs/tags/${{ steps.parse.outputs.version }}" >/dev/null 2>&1; then
+            echo "::notice::Tag already exists; nothing to do."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag and publish release
+        if: steps.tag_check.outputs.exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.parse.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$version" -m "Release $version"
+          git push origin "$version"
+
+          (cd client && zip -r /tmp/client-dist.zip dist)
+
+          gh release create "$version" \
+            --title "$version" \
+            --notes-file /tmp/notes.md \
+            /tmp/client-dist.zip

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,29 @@
+# Releases
+
+## [Unreleased]
+
+## [v0.2.0] - 2026-04-29
+
+Test release for automation
+
+<!--
+Release process:
+
+1. Add a new section under "## [Unreleased]" using the format:
+
+       ## [vX.Y.Z] - YYYY-MM-DD
+
+       - Bullet points of user-visible changes
+       - One per line, in past tense
+
+2. Push to main. The release-prepare workflow will:
+   - Pull latest dist from dyalog/ewc-client@main
+   - Open a "Release vX.Y.Z" PR if client/dist/ changed
+   - Otherwise tag and release directly
+
+3. Review and merge the release PR. The release-publish workflow then
+   creates tag vX.Y.Z and publishes a GitHub Release with these notes.
+
+The version at the top of this file is the one that will be released.
+Versions already tagged are skipped.
+-->


### PR DESCRIPTION
Releases driven by RELEASES.md changes on main.
Pulls latest dist from dyalog/ewc-client@main and either opens a release PR (if dist changed) or tags + releases directly.