### PR TITLE
Add EWC.LOGFILE option

### DIFF
--- a/EWC/Doc/Debugging.apla
+++ b/EWC/Doc/Debugging.apla
@@ -17,6 +17,8 @@
  '  '
  ' Set LOGMODES←'''' to suppress all logging or to ⎕A to enable full logging.'
  (' '⋄)
+ ' LOG output can be redirected to a file by setting EWC.LOGFILE to a path.'
+ (' '⋄)
  ' BREAKPOINTS can be set using the function BreakOn. For example:'
  (' '⋄)
  '     BreakOn ''ID'' ''F1.E1''       ⍝ Stop WC/WS or event processing for object ''F1.E1'''

--- a/EWC/Log.aplf
+++ b/EWC/Log.aplf
@@ -14,4 +14,8 @@ mode Log msg
 ⍝ K: Keep-Alive
 
 →(mode∊LOGMODES)↓0
-⎕←((,'ZI2,<:>,ZI2,<.>,ZI3' ⎕FMT 1 3⍴¯3↑⎕TS),' ',mode,':') msg
+:If 0≠≢LOGFILE
+    (⊂⍕((,'ZI2,<:>,ZI2,<.>,ZI3' ⎕FMT 1 3⍴¯3↑⎕TS),' ',mode,':') msg) ⎕NPUT LOGFILE 2
+:Else
+    ⎕←((,'ZI2,<:>,ZI2,<.>,ZI3' ⎕FMT 1 3⍴¯3↑⎕TS),' ',mode,':') msg
+:EndIf

--- a/EWC/classes/button/SupportedEvents.apla
+++ b/EWC/classes/button/SupportedEvents.apla
@@ -6,4 +6,5 @@
  'MouseEnter'
  'MouseMove'
  'MouseLeave'
+ 'Change'
 )

--- a/EWC/classes/combo/SupportedEvents.apla
+++ b/EWC/classes/combo/SupportedEvents.apla
@@ -5,4 +5,5 @@
  'MouseEnter'
  'MouseMove'
  'MouseLeave'
+ 'KeyPress'
 )

--- a/EWC/setDefaults.aplf
+++ b/EWC/setDefaults.aplf
@@ -3,6 +3,7 @@ setDefaults
 
  'MAXLOG'       default 2000
  'LOGMODES'     default ⎕A ⍝ Log everything (see Log)
+ 'LOGFILE'      default ''
  'RESOURCES'    default 1 2⍴⊂''
  'PORT'         default 22322
  'MAXSESSIONS'  default 100

--- a/docs/Usage/Configuration.md
+++ b/docs/Usage/Configuration.md
@@ -65,6 +65,22 @@ At the time that this text was written, the following modes existed:
 
 An up-to-date list can be found in the function `EWC.Log`.
 
+## LOGFILE
+
+When set to a file path, all log output is redirected to that file instead of
+the APL session. Output is appended; the file is created if it does not exist.
+Redirecting to a file can improve performance by avoiding session output.
+
+```
+EWC.LOGFILE←'/tmp/myapp.log'
+```
+
+Set to `''` to keep session output (the default):
+
+```
+EWC.LOGFILE←''
+```
+
 ## For Developers
 
 The following configuration settings are intended for use during development of EWC


### PR DESCRIPTION
Printing to the session is time-consuming and can actually slow down running applications. We want to keep logs, but use a differnt path to create logs. It should be quicker, and you get a greppable log file in the cases when dyalog freezes or dies.