### PR TITLE
Fix blank first navigation in Browser mode (connection 0 dropped)

### DIFF
--- a/EWC/SendSettings.aplf
+++ b/EWC/SendSettings.aplf
@@ -2,6 +2,8 @@ SendSettings CONN;S;z;msg
 ⍝ Send various contents of "Options"
 ⍝ For valid Locale settings, see https://day.js.org/docs/en/display/format
 
+:If CONN<0 ⋄ :Return ⋄ :EndIf ⍝ ¯1 ⇒ no valid connection (getConnection miss); nothing to send
+
 S←⎕NS ''
 S.Options←⎕NS ''
 S.Options.ID←'Mode'

--- a/EWC/dEX.aplf
+++ b/EWC/dEX.aplf
@@ -13,7 +13,7 @@
  R←caller.⎕EX names
  msg←⎕JSON EX
 
- :If CONNECTED
+ :If CONNECTED∧conn≥0
      z←conn WSS.Send msg
      'T' Log msg
  :Else

--- a/EWC/dNQ.aplf
+++ b/EWC/dNQ.aplf
@@ -90,7 +90,7 @@
 
  msg←⎕JSON⍠'HighRank' 'Split'⊢NQ
 
- :If CONNECTED
+ :If CONNECTED∧conn≥0
      'T' Log '#',(⍕conn),': ',msg
      z←conn WSS.Send msg
  :Else

--- a/EWC/dWX.aplf
+++ b/EWC/dWX.aplf
@@ -17,7 +17,7 @@
  wx.(ID Method Info WGID)←Name Method Info(⍕WGID)
 
  msg←⎕JSON⍠'HighRank' 'Split'⊢WX
- :If CONNECTED
+ :If CONNECTED∧conn≥0
      'T'Log'#',(⍕conn),': ',msg
      z←conn WSS.Send msg
  :Else

--- a/EWC/getConnection.aplf
+++ b/EWC/getConnection.aplf
@@ -18,6 +18,6 @@
      :Trap 0
          r←CODELOCATION._EWC.(ID conn)
      :Else
-         r←0 0
+         r←0 ¯1 ⍝ no connection: ¯1 is an invalid conn (0 is a VALID Conga connection)
      :EndTrap
  :EndIf

--- a/EWC/sendObject.aplf
+++ b/EWC/sendObject.aplf
@@ -2,7 +2,7 @@ caller sendObject (obj name);msg;z;conn;ID
 
  msg←⎕JSON⍠'HighRank' 'Split'⊢obj
  (ID conn)←getConnection caller name
- :If conn≠0
+ :If conn≥0 ⍝ conn 0 is a valid connection; ¯1 means none was found
      'T' Log '#',(⍕conn),': ',((MAXLOG⌊≢msg)↑msg),(MAXLOG<≢msg)/'...'
      z←conn WSS.Send msg
  :EndIf

--- a/EWC/sendWGmsg.aplf
+++ b/EWC/sendWGmsg.aplf
@@ -6,7 +6,7 @@
 
  wg.(WGID ID Properties)←wgid Name Props
  msg←⎕JSON WG
- :If CONNECTED
+ :If CONNECTED∧conn≥0
      'T'Log'#',(⍕conn),': ',msg
      z←conn WSS.Send msg
  :Else


### PR DESCRIPTION
Connection number 0 is a valid Conga connection, but EWC was treating it as invalid. This resolves the issue where you must refresh on every first load. Desktop mode did this for you, but Browser couldn't.

Use ¯1 (an impossible Conga connection number) as the no-connection sentinel instead of 0.